### PR TITLE
CATL-1877: Fix 'With contact' for email activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ able to download and open this file with some email application
 (e.g: Thunderbird, Outlook) to view all details of the original email. This may
 be useful in some legal cases for example.
 
-This module affects all webforms that are configured:
-1. For CiviCRM processing.
-1. To create/update a Case.
-1. To send an email (notification).
-
 ## Installation
 
 To install this module, place it in your sites/all/modules folder and enable it
@@ -19,6 +14,18 @@ on the modules page as usual.
 ## Configuration
 
 This module has no configuration - just enable it and enjoy.
+
+## Usage
+
+This module affects all webforms that are configured:
+1. For CiviCRM processing.
+1. To create/update a Case.
+1. To send an email (notification).
+
+Check if you've configured a webform properly:
+1. Make sure that contact with `From` address exists. Civicrm would not create an activity if no matching contact is found (creator is required).
+1. Webform module tends to send emails using site default email (see *Site information* page - */admin/config/system/site-information*) as `From` address, despite that actual `From` address is set in the webform configuration. So you may want to set address of some existing contact here or create new contact for that.
+1. If you need to have `To` contact in new activity (it would be assigned as `With` contact), ensure that contact with this address exists.
 
 ## Credit
 

--- a/includes/WcfceMailProcessor.inc
+++ b/includes/WcfceMailProcessor.inc
@@ -47,8 +47,8 @@ class WcfceMailProcessor {
       return FALSE;
     }
 
-    $assignee_id = $this->getContactIdByEmail($this->message['to']);
-    $creator_id  = $this->getContactIdByEmail($this->message['from']);
+    $target_id = $this->getContactIdByEmail($this->message['to']);
+    $creator_id = $this->getContactIdByEmail($this->message['from']);
 
     if (!$creator_id) {
       return FALSE;
@@ -66,7 +66,7 @@ class WcfceMailProcessor {
         'case_id' => $case['id'],
         'subject' => $this->message['subject'],
         'details' => trim($this->message['body'][0]),
-        'assignee_id' => $assignee_id,
+        'target_id' => $target_id,
         'source_contact_id' => $creator_id,
       ]);
 

--- a/includes/WcfceMailProcessor.inc
+++ b/includes/WcfceMailProcessor.inc
@@ -119,7 +119,7 @@ class WcfceMailProcessor {
     if (!empty($result['id'])) {
       civicrm_api3('File', 'create', [
         'id' => $result['id'],
-        'file_type_id' => 1,
+        'file_type_id' => $this->getOriginalEmailFileTypeId(),
       ]);
     }
 
@@ -446,6 +446,18 @@ class WcfceMailProcessor {
     }
 
     return $this->crlf;
+  }
+
+  /**
+   * Returns id of 'Original email' file type.
+   *
+   * @return int
+   *   The id of 'Original email' file type.
+   */
+  private function getOriginalEmailFileTypeId() {
+    // The file_type_id column exists in civicrm_file db table, but never used
+    // and there are no actual types defined. So let's return a value directly.
+    return 1;
   }
 
 }


### PR DESCRIPTION
## Overview
Activities created on webform submission has empty **With Contact** field and not empty **Assigned To**, but according to the [spec](https://compucorp.atlassian.net/wiki/spaces/CPS/pages/2248441926/NEU+CR+3D+Store+a+copy+of+webform+automated+emails+on+the+CiviCRM+case+including+a+copy+of+the+file+in+.eml+format+v1.0) it should be visa versa. This PR fixes the issue.

## Before
![image](https://user-images.githubusercontent.com/39520000/96412866-6ee29400-11f3-11eb-8122-dd1e49ba2212.png)

## After
![image](https://user-images.githubusercontent.com/39520000/96412823-612d0e80-11f3-11eb-8013-6c0eeb5dcee5.png)

## Technical Details
The `WcfceMailProcessor->createActivity()` method was fixed - now contact matching `To` address is set as activity `target_id` instead of `assignee_id`. This issue came from the [previous PR](https://github.com/compucorp/webform_civicrm_file_case_emails/pull/1).

Also as part of this PR `getOriginalEmailFileTypeId()` method is added to avoid hardcoded values in the code. Technically speaking hardcoded value is inside this method now, but this makes it safe to use this method instead of actual value in other places. Later if some file types will be added to civicrm (atm there are no respective option group) this method could be refactored.