### PR TITLE
CATL-1877: Update dependencies and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ on the modules page as usual.
 
 This module has no configuration - just enable it and enjoy.
 
+However you need to check if mail system settings are configured properly:
+1. Go to Configuration -> System -> Mail System page
+(*/admin/config/system/mailsystem*).
+1. Make sure that *Site-wide default MailSystemInterface class* field has
+*MimeMailSystem* value selected.
+
 ## Usage
 
 This module affects all webforms that are configured:

--- a/webform_civicrm_file_case_emails.info
+++ b/webform_civicrm_file_case_emails.info
@@ -3,4 +3,6 @@ description = Files webform notification emails as case activities with original
 core = 7.x
 version = 7.x-1.0
 package = CiviCRM
+dependencies[] = mimemail
 dependencies[] = webform_civicrm
+


### PR DESCRIPTION
## Overview
After some testing it turned out that we need to add **Mime Mail** module as a dependency here. We also updated readme file to leave a note regarding it's configuration.
It was not spotted previously as module was tested on compuclient based site, where **Mime Mail** module is enabled by default.