### PR TITLE
CATL-1991: Fix error when using SMTP mail transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@ on the modules page as usual.
 
 This module has no configuration - just enable it and enjoy.
 
-However, you need to check if mail system settings are configured properly:
-1. Go to Configuration -> System -> Mail System page
-(*/admin/config/system/mailsystem*).
-1. Make sure that *Site-wide default MailSystemInterface class* field has
-*MimeMailSystem* value selected.
-
 ## Usage
 
 This module affects all webforms that are configured:

--- a/webform_civicrm_file_case_emails.module
+++ b/webform_civicrm_file_case_emails.module
@@ -14,6 +14,12 @@ function webform_civicrm_file_case_emails_mail_alter(array &$message) {
     return;
   }
 
+  // Make sure dependency is included.
+  // (The mimemail_rfc_headers() would be required during processing)
+  if (!module_load_include('inc', 'mimemail', 'mimemail')) {
+    return;
+  }
+
   // Include mail processor class.
   if (!module_load_include('inc', 'webform_civicrm_file_case_emails', 'includes/WcfceMailProcessor')) {
     return;


### PR DESCRIPTION
## Overview
As you may remember this module creates an activity out of email sent on webform submission. It worked fine on compuclient site, but was failing on the NEU client site with a message:
```
Error: Call to undefined function mimemail_rfc_headers() in WcfceMailProcessor->generateEml() (line 190 of /var/www/mcaws.neu.org.uk/httpdocs/sites/all/modules/contrib/webform_civicrm_file_case_emails/includes/WcfceMailProcessor.inc).
```

Now the issue is fixed.

## Before
No activity was created due to php error.

## After
Activity is created (with eml file attached), no errors.

## Technical Details
After some investigation it turned out that smtp transport is used on client site, but this module was not tested with that transport. Previously mime transport was used, see _Site-wide default MailSystemInterface class_ field on _Mail System_ page (`/admin/config/system/mailsystem`):
![image](https://user-images.githubusercontent.com/39520000/100323723-36df2580-2fd7-11eb-9692-2de74e42c310.png)

After further investigation it turned out that the `mimemail.inc` file of the _Mime mail_ module was not included when smtp transport is used, hence `mimemail_rfc_headers()` from that file was not defined.
So to fix the issue we added a code to include that file anyway. It was tested with default / mime / smtp / testing transports and works fine.

Also as part of this PR:
* The readme file was updated, as having mime transport is not a requirement now.
* The module version is changed from 7.x-1.1 to 7.x-1.2 as part of preparation for release.