### PR TITLE
CATL-1991: Change module version from 7.x-1.1 to 7.x-1.2

### DIFF
--- a/webform_civicrm_file_case_emails.info
+++ b/webform_civicrm_file_case_emails.info
@@ -1,7 +1,7 @@
 name = Webform CiviCRM File Case Emails
 description = Files webform notification emails as case activities with original emails attached.
 core = 7.x
-version = 7.x-1.1
+version = 7.x-1.2
 package = CiviCRM
 dependencies[] = mimemail
 dependencies[] = webform_civicrm


### PR DESCRIPTION
## Overview
Here we're changing the module version from 7.x-1.1 to 7.x-1.2 as part of preparation for release.
