### PR TITLE
NEUSPRT-171: Format EML files using the mimemail system

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -9,16 +9,16 @@ jobs:
   run-linters:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 2
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Coder and Codesniffer
-        run: composer global require drupal/coder dealerdirect/phpcodesniffer-composer-installer &&
-          ~/.composer/vendor/bin/phpcs --config-set installed_paths ~/.composer/vendor/drupal/coder/coder_sniffer
+      - name: Install phpcs
+        run: cd bin && ./install-php-linter
 
       - name: Fetch target branch
         run: git fetch -n origin ${GITHUB_BASE_REF}
 
-      - name: Run phpcs
-        run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' '*.module' '*.inc' '*.install' '*.theme' ':!*.features.*' | xargs -r ~/.composer/vendor/bin/phpcs --standard=phpcs.xml
+      - name: Run phpcs with Drupal coding standards
+        run: git diff --diff-filter=d  origin/${GITHUB_BASE_REF} --name-only -- '*.php' '*.module' '*.inc' '*.install' '*.theme' ':!*.features.*' | xargs -r ./bin/drupal/coder/vendor/bin/phpcs --standard=phpcs.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+./bin/drupal

--- a/bin/install-php-linter
+++ b/bin/install-php-linter
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Clone Drupal Coder repo
+if [ ! -d drupal/coder ]; then
+  git clone --depth 1 https://git.drupalcode.org/project/coder.git drupal/coder
+  cd drupal/coder
+  composer install
+fi

--- a/includes/WcfceMailProcessor.inc
+++ b/includes/WcfceMailProcessor.inc
@@ -176,9 +176,7 @@ class WcfceMailProcessor {
   private function generateEml($message = NULL) {
     $message = $message ?? $this->message;
 
-    // (Copied from drupal_mail())
-    // Retrieve the responsible implementation for this message.
-    $system = drupal_mail_system($message['module'], $message['key']);
+    $system = new MimeMailSystem();
     // Format the message body.
     $message = $system->format($message);
 

--- a/includes/WcfceMailProcessor.inc
+++ b/includes/WcfceMailProcessor.inc
@@ -193,7 +193,11 @@ class WcfceMailProcessor {
     $eml .= 'To: ' . implode($this->crlf() . 'To: ', $recipients) . $this->crlf();
     $eml .= 'Subject: ' . $subject . $this->crlf() . $this->crlf();
     $eml .= $body;
-    $eml = $this->appendWebformFilesToEml($eml, $message);
+
+    // Only append files if they're not already included as attachments.
+    if (empty($message['params']['attachments'])) {
+      $eml = $this->appendWebformFilesToEml($eml, $message);
+    }
 
     return $eml;
   }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="PHPCS Drupal Ruleset">
-  <description>PHP CodeSniffer configuration.</description>
+  <description>PHP CodeSniffer configuration for Drupal development.</description>
 
   <arg name="extensions" value="php,module,inc,install,theme"/>
 
   <config name="drupal_core_version" value="7"/>
 
   <!-- Drupal sniffs -->
-  <rule ref="Drupal">
+  <rule ref="bin/drupal/coder/coder_sniffer/Drupal">
     <exclude name="Drupal.Files.TxtFileLineLength.TooLong"/>
+    <exclude name="Drupal.Commenting.FileComment.FileTag"/>
+    <exclude name="Drupal.Commenting.FileComment.ShortSingleLine"/>
+    <exclude name="Drupal.Commenting.DocComment.ShortSingleLine"/>
+    <exclude name="Drupal.NamingConventions.ValidClassName"/>
   </rule>
 </ruleset>


### PR DESCRIPTION
## Overview
In this PR we format the generated EML files using the `mimemail` system and also ensure duplicate files are not attached.

## Before
The attachment files are not displayed in the EML file if the mail was sent using SMTP.

_Mail is configured to be sent using SMTP._
<img width="648" alt="Screenshot 2023-02-01 at 08 49 26" src="https://user-images.githubusercontent.com/85277674/215984236-840d167e-d949-49a9-81a2-07cf712f873a.png">

_The file is set to be attached as an attachment._
<img width="1238" alt="Screenshot 2023-02-01 at 08 40 45" src="https://user-images.githubusercontent.com/85277674/215980991-06747af8-fa64-457a-8468-c4c60a9ca632.png">

No file is attached instead displays raw base64
![image](https://user-images.githubusercontent.com/85277674/215986515-1d526388-4359-4951-8fd3-b116d7e9f19a.png)

## After
The attachment files are now displayed in the EML file if the mail was sent using SMTP.

_The file is attached to the EML file_
<img width="1178" alt="Screenshot 2023-02-01 at 08 56 43" src="https://user-images.githubusercontent.com/85277674/215987336-60e58b80-acc8-4a72-9201-dae7b96b2ac2.png">


## Technical Details
We are now using the `MimeMail` system to format the EML files irrespective of the systemwide settings because other mail systems produce inconsistent results with the attachment of files. For example, the `SMTPMailSystem` includes the file as a base64 string that is not renderable by an email client.

We've also added a check to ensure that files are not attached twice to the EML, this duplicate attachment happens if the webform is already configured to attach uploaded file files as an attachment.
<img width="1238" alt="Screenshot 2023-02-01 at 08 40 45" src="https://user-images.githubusercontent.com/85277674/215984215-462c37ad-09a5-4a02-9bc8-d524ebaba14a.png">

